### PR TITLE
feat: 招待制ログイン機能の実装とドメイン制限の追加

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -1,8 +1,9 @@
-import { createClient } from "@/utils/supabase/server";
-import { redirect } from "next/navigation";
-import { LogOut } from "lucide-react";
+import AdminInviteUserModal from "@/components/AdminInviteUserModal";
 import AdminSearchFilter from "@/components/AdminSearchFilter";
 import StudentEditModal from "@/components/StudentEditModal";
+import { createClient } from "@/utils/supabase/server";
+import { LogOut } from "lucide-react";
+import { redirect } from "next/navigation";
 
 export default async function AdminDashboard({
     searchParams,
@@ -164,6 +165,7 @@ export default async function AdminDashboard({
                 </div>
                 <div className="w-full flex gap-3 items-center">
                     <AdminSearchFilter courses={courses || []} />
+                    <AdminInviteUserModal courses={courses || []} />
                 </div>
             </header>
 

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -3,9 +3,9 @@
 import { createClient } from "@/utils/supabase/client";
 import { Loader2 } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 
-export default function AuthCallbackPage() {
+function AuthCallbackContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [error, setError] = useState<string | null>(null);
@@ -115,5 +115,20 @@ export default function AuthCallbackPage() {
         <p className="mt-2 text-slate-500">認証中...</p>
       </div>
     </div>
+  );
+}
+
+export default function AuthCallbackPage() {
+  return (
+    <Suspense fallback={
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="text-center">
+          <Loader2 className="h-8 w-8 animate-spin mx-auto text-indigo-600" />
+          <p className="mt-2 text-slate-500">読み込み中...</p>
+        </div>
+      </div>
+    }>
+      <AuthCallbackContent />
+    </Suspense>
   );
 }

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { createClient } from "@/utils/supabase/client";
+import { Loader2 } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+
+export default function AuthCallbackPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handleAuth = async () => {
+      console.log("Auth Callback: Starting...");
+      const supabase = createClient();
+      const next = searchParams.get("next") || "/";
+      const code = searchParams.get("code");
+      
+      console.log("Params:", { next, code, hash: window.location.hash });
+
+      // 1. PKCE Flow (Code Exchange)
+      if (code) {
+        console.log("Auth Callback: Handling PKCE code...");
+        const { error } = await supabase.auth.exchangeCodeForSession(code);
+        if (error) {
+          console.error("PKCE Error:", error);
+          setError(error.message);
+          return;
+        }
+        console.log("Auth Callback: PKCE Success, redirecting to", next);
+        router.replace(next);
+        return;
+      }
+
+      // 2. Implicit Flow (Hash Handling)
+      console.log("Auth Callback: Checking session for Implicit Flow...");
+      
+      // Attempt manual hash parsing first if present (Robuster for some environments)
+      const hash = window.location.hash;
+      if (hash && hash.includes("access_token")) {
+         console.log("Auth Callback: Hash detected, attempting manual parsing...");
+         const params = new URLSearchParams(hash.substring(1)); // remove #
+         const accessToken = params.get("access_token");
+         const refreshToken = params.get("refresh_token");
+
+         if (accessToken && refreshToken) {
+             const { error: setSessionError } = await supabase.auth.setSession({
+                 access_token: accessToken,
+                 refresh_token: refreshToken,
+             });
+             if (!setSessionError) {
+                 console.log("Auth Callback: Manual session set success, redirecting...");
+                 router.replace(next);
+                 return;
+             }
+             console.error("Manual SetSession Error:", setSessionError);
+         }
+      }
+
+      // Standard check
+      const { data: { session }, error: sessionError } = await supabase.auth.getSession();
+      console.log("Session Check:", { session, error: sessionError });
+      
+      if (sessionError) {
+        setError(sessionError.message);
+        return;
+      }
+
+      if (session) {
+        // Successful implicit login
+        console.log("Auth Callback: Session found, redirecting to", next);
+        router.replace(next);
+        return;
+      }
+
+      // 3. Listen for auth state change (Fallback)
+      console.log("Auth Callback: Waiting for auth state change...");
+      const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
+        console.log("Auth State Change:", event, session);
+        if (event === "SIGNED_IN" && session) {
+            router.replace(next);
+        }
+      });
+
+      return () => {
+        subscription.unsubscribe();
+      };
+    };
+
+    handleAuth();
+  }, [router, searchParams]);
+
+  if (error) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center">
+        <div className="bg-red-50 p-4 rounded-md text-red-600">
+            <h3 className="font-bold">認証エラー</h3>
+            <p>{error}</p>
+            <button 
+                onClick={() => router.push("/login")}
+                className="mt-4 text-sm underline hover:text-red-800"
+            >
+                ログイン画面へ戻る
+            </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="text-center">
+        <Loader2 className="h-8 w-8 animate-spin mx-auto text-indigo-600" />
+        <p className="mt-2 text-slate-500">認証中...</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/auth/update-password/actions.ts
+++ b/src/app/auth/update-password/actions.ts
@@ -1,0 +1,39 @@
+"use server";
+
+import { createClient } from "@/utils/supabase/server";
+import { redirect } from "next/navigation";
+import { z } from "zod";
+
+const PasswordSchema = z.object({
+  password: z.string().min(6, "パスワードは6文字以上で入力してください"),
+  confirmPassword: z.string().min(6, "確認用パスワードは6文字以上で入力してください"),
+}).refine((data) => data.password === data.confirmPassword, {
+  message: "パスワードが一致しません",
+  path: ["confirmPassword"],
+});
+
+export async function updatePassword(formData: FormData) {
+  const supabase = await createClient();
+  
+  const validated = PasswordSchema.safeParse({
+    password: formData.get("password"),
+    confirmPassword: formData.get("confirmPassword"),
+  });
+
+  if (!validated.success) {
+    return { error: validated.error.issues[0].message };
+  }
+
+  const { password } = validated.data;
+
+  const { error } = await supabase.auth.updateUser({
+    password: password,
+  });
+
+  if (error) {
+    console.error("Password update error:", error);
+    return { error: "パスワードの更新に失敗しました" };
+  }
+
+  redirect("/");
+}

--- a/src/app/auth/update-password/page.tsx
+++ b/src/app/auth/update-password/page.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+import { updatePassword } from "./actions";
+
+export default function UpdatePasswordPage() {
+    const [error, setError] = useState<string | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+
+    const handleSubmit = async (formData: FormData) => {
+        setIsLoading(true);
+        setError(null);
+
+        const result = await updatePassword(formData);
+        
+        if (result?.error) {
+            setError(result.error);
+            setIsLoading(false);
+        }
+        // Success redirects in action
+    };
+
+    return (
+        <div className="flex min-h-screen flex-col items-center justify-center bg-slate-50 px-6 py-12 lg:px-8">
+            <div className="sm:mx-auto sm:w-full sm:max-w-sm">
+                <h2 className="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-slate-900">
+                    パスワードの設定
+                </h2>
+                <p className="mt-2 text-center text-sm text-slate-600">
+                    新しいパスワードを入力してください
+                </p>
+            </div>
+
+            <div className="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
+                <form action={handleSubmit} className="space-y-6">
+                    <div>
+                        <label htmlFor="password" className="block text-sm font-medium leading-6 text-slate-900">
+                            新しいパスワード
+                        </label>
+                        <div className="mt-2">
+                            <input
+                                id="password"
+                                name="password"
+                                type="password"
+                                required
+                                minLength={6}
+                                className="block w-full rounded-md border-0 py-1.5 text-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 placeholder:text-slate-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6 px-3"
+                            />
+                        </div>
+                    </div>
+
+                    <div>
+                        <label htmlFor="confirmPassword" className="block text-sm font-medium leading-6 text-slate-900">
+                            パスワード（確認）
+                        </label>
+                        <div className="mt-2">
+                            <input
+                                id="confirmPassword"
+                                name="confirmPassword"
+                                type="password"
+                                required
+                                minLength={6}
+                                className="block w-full rounded-md border-0 py-1.5 text-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 placeholder:text-slate-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6 px-3"
+                            />
+                        </div>
+                    </div>
+
+                    {error && (
+                        <div className="text-red-500 text-sm text-center">
+                            {error}
+                        </div>
+                    )}
+
+                    <div>
+                        <button
+                            type="submit"
+                            disabled={isLoading}
+                            className="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed items-center gap-2"
+                        >
+                            {isLoading && <Loader2 size={16} className="animate-spin" />}
+                            パスワードを設定してログイン
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,5 @@
 import { createClient } from "@/utils/supabase/server";
-import { login, signup } from "./actions";
+import { login } from "./actions";
 
 export default async function LoginPage({
     searchParams,
@@ -19,69 +19,13 @@ export default async function LoginPage({
                         就職支援管理
                     </h1>
                     <p className="mt-3 text-sm text-slate-600 dark:text-slate-400">
-                        {isSignup ? "新しいアカウントを作成しましょう" : "おかえりなさい！ログインしてください"}
+                        おかえりなさい！ログインしてください
                     </p>
                 </div>
 
-                {/* Tab Switcher */}
-                <div className="flex p-1 bg-slate-100 dark:bg-slate-800 rounded-lg">
-                    <a
-                        href="/login?mode=login"
-                        className={`flex-1 text-center py-2 text-sm font-medium rounded-md transition-all ${!isSignup
-                                ? "bg-white dark:bg-slate-700 text-indigo-600 shadow-sm"
-                                : "text-slate-500 hover:text-slate-700"
-                            }`}
-                    >
-                        ログイン
-                    </a>
-                    <a
-                        href="/login?mode=signup"
-                        className={`flex-1 text-center py-2 text-sm font-medium rounded-md transition-all ${isSignup
-                                ? "bg-white dark:bg-slate-700 text-indigo-600 shadow-sm"
-                                : "text-slate-500 hover:text-slate-700"
-                            }`}
-                    >
-                        新規登録
-                    </a>
-                </div>
 
                 <form className="space-y-5">
                     <div className="space-y-3">
-                        {isSignup && (
-                            <>
-                                <div className="space-y-1">
-                                    <label htmlFor="full_name" className="text-xs font-semibold text-slate-500 uppercase ml-1">
-                                        氏名
-                                    </label>
-                                    <input
-                                        id="full_name"
-                                        name="full_name"
-                                        type="text"
-                                        required
-                                        className="block w-full rounded-lg border-0 py-2 text-slate-900 ring-1 ring-inset ring-slate-300 placeholder:text-slate-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm px-3"
-                                        placeholder="山田 太郎"
-                                    />
-                                </div>
-                                <div className="space-y-1">
-                                    <label htmlFor="course_id" className="text-xs font-semibold text-slate-500 uppercase ml-1">
-                                        コース
-                                    </label>
-                                    <select
-                                        id="course_id"
-                                        name="course_id"
-                                        required
-                                        className="block w-full rounded-lg border-0 py-2 text-slate-900 ring-1 ring-inset ring-slate-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm px-3 bg-white"
-                                    >
-                                        <option value="">コースを選択してください</option>
-                                        {courses?.map((course) => (
-                                            <option key={course.id} value={course.id}>
-                                                {course.name}
-                                            </option>
-                                        ))}
-                                    </select>
-                                </div>
-                            </>
-                        )}
 
                         <div className="space-y-1">
                             <label htmlFor="email" className="text-xs font-semibold text-slate-500 uppercase ml-1">
@@ -125,21 +69,12 @@ export default async function LoginPage({
                     )}
 
                     <div className="pt-2">
-                        {!isSignup ? (
                             <button
                                 formAction={login}
                                 className="w-full flex justify-center py-2.5 px-4 border border-transparent rounded-lg shadow-sm text-sm font-bold text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors"
                             >
                                 ログイン
                             </button>
-                        ) : (
-                            <button
-                                formAction={signup}
-                                className="w-full flex justify-center py-2.5 px-4 border border-transparent rounded-lg shadow-sm text-sm font-bold text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors"
-                            >
-                                アカウントを作成する
-                            </button>
-                        )}
                     </div>
                 </form>
 

--- a/src/components/AdminInviteUserModal.tsx
+++ b/src/components/AdminInviteUserModal.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { inviteUser } from "@/app/admin/dashboard/actions";
+import { Loader2, Mail, Plus, X } from "lucide-react";
+import { useState } from "react";
+
+type Course = {
+    id: string;
+    name: string;
+};
+
+export default function AdminInviteUserModal({ courses }: { courses: Course[] }) {
+    const [isOpen, setIsOpen] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+    const [message, setMessage] = useState<{ type: 'success' | 'error', text: string } | null>(null);
+
+    async function handleSubmit(formData: FormData) {
+        setIsLoading(true);
+        setMessage(null);
+        
+        try {
+            const result = await inviteUser(formData);
+            if (result.error) {
+                setMessage({ type: 'error', text: result.error });
+            } else {
+                setMessage({ type: 'success', text: "招待メールを送信しました" });
+                // Reset form or close modal after delay if needed
+                setTimeout(() => {
+                    setIsOpen(false);
+                    setMessage(null);
+                }, 2000);
+            }
+        } catch (e) {
+            setMessage({ type: 'error', text: "予期せぬエラーが発生しました" });
+        } finally {
+            setIsLoading(false);
+        }
+    }
+
+    if (!isOpen) {
+        return (
+            <button
+                onClick={() => setIsOpen(true)}
+                className="flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-bold rounded-lg shadow-sm hover:bg-indigo-700 transition-all"
+            >
+                <Plus size={16} />
+                新規ユーザー招待
+            </button>
+        );
+    }
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-slate-900/50 backdrop-blur-sm">
+            <div className="bg-white dark:bg-slate-900 rounded-xl shadow-2xl w-full max-w-md border border-slate-200 dark:border-slate-800">
+                <div className="flex items-center justify-between p-4 border-b border-slate-100 dark:border-slate-800">
+                    <h2 className="text-lg font-bold text-slate-900 dark:text-white flex items-center gap-2">
+                        <Mail className="text-indigo-600" size={20} />
+                        ユーザーを招待
+                    </h2>
+                    <button
+                        onClick={() => setIsOpen(false)}
+                        className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
+                    >
+                        <X size={20} />
+                    </button>
+                </div>
+
+                <form action={handleSubmit} className="p-4 space-y-4">
+                    {message && (
+                        <div className={`p-3 rounded-lg text-sm font-medium ${message.type === 'success' ? 'bg-emerald-50 text-emerald-700' : 'bg-red-50 text-red-700'}`}>
+                            {message.text}
+                        </div>
+                    )}
+
+                    <div className="space-y-1">
+                        <label htmlFor="email" className="text-xs font-bold text-slate-500 uppercase">メールアドレス</label>
+                        <input
+                            type="email"
+                            name="email"
+                            id="email"
+                            required
+                            placeholder="user@example.com"
+                            className="block w-full rounded-lg border-slate-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm px-3 py-2 border"
+                        />
+                    </div>
+
+                    <div className="space-y-1">
+                        <label htmlFor="full_name" className="text-xs font-bold text-slate-500 uppercase">氏名</label>
+                        <input
+                            type="text"
+                            name="full_name"
+                            id="full_name"
+                            required
+                            placeholder="山田 太郎"
+                            className="block w-full rounded-lg border-slate-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm px-3 py-2 border"
+                        />
+                    </div>
+
+                    <div className="space-y-1">
+                        <label htmlFor="course_id" className="text-xs font-bold text-slate-500 uppercase">コース</label>
+                        <select
+                            name="course_id"
+                            id="course_id"
+                            required
+                            className="block w-full rounded-lg border-slate-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm px-3 py-2 border bg-white"
+                        >
+                            <option value="">コースを選択</option>
+                            {courses.map(course => (
+                                <option key={course.id} value={course.id}>{course.name}</option>
+                            ))}
+                        </select>
+                    </div>
+                     <div className="space-y-1">
+                        <label htmlFor="role_id" className="text-xs font-bold text-slate-500 uppercase">権限</label>
+                        <select
+                            name="role_id"
+                            id="role_id"
+                            required
+                            defaultValue="student"
+                            className="block w-full rounded-lg border-slate-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm px-3 py-2 border bg-white"
+                        >
+                            <option value="student">受講生 (Student)</option>
+                            <option value="admin">管理者 (Admin)</option>
+                        </select>
+                    </div>
+
+                    <div className="pt-2 flex justify-end gap-2">
+                        <button
+                            type="button"
+                            onClick={() => setIsOpen(false)}
+                            className="px-4 py-2 text-sm font-medium text-slate-700 bg-white border border-slate-300 rounded-lg hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                        >
+                            キャンセル
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={isLoading}
+                            className="flex items-center gap-2 px-4 py-2 text-sm font-bold text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            {isLoading && <Loader2 size={16} className="animate-spin" />}
+                            招待メールを送信
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,6 +1,6 @@
+import { createAdminClient } from "@/utils/supabase/admin";
 import { createClient } from "@/utils/supabase/server";
 import { headers } from "next/headers";
-import { UAParser } from "ua-parser-js";
 
 export type LogLevel = "INFO" | "WARN" | "ERROR" | "CRITICAL";
 
@@ -86,8 +86,9 @@ export class Logger {
                 changedFields = this.calculateChangedFields(params.old_value, params.new_value);
             }
 
-            // DBへ保存
-            const { error } = await supabase.from("activity_logs").insert({
+            // DBへ保存 (RLS回避のためAdminクライアントを使用)
+            const supabaseAdmin = createAdminClient();
+            const { error } = await supabaseAdmin.from("activity_logs").insert({
                 // 基本情報
                 request_id: this.context.requestId,
                 environment: environment,


### PR DESCRIPTION
## 概要
招待制ログイン機能の導入と、セキュリティ向上のための各種修正を行いました。

## 関連Issue
Closes #1
Closes #2

## 変更内容
### #1 招待制の導入
- ログインページから公開サインアップフォームを削除
- 管理者ダッシュボードにユーザー招待用モーダルを追加
- 管理者用API（Service Role）を使用した招待メール送信機能を実装
- 招待されたユーザーがパスワードを設定するための専用フロー（コールバック + パスワード更新ページ）を構築

### #2 メールドメイン制限
- 環境変数 `ALLOWED_EMAIL_DOMAINS` を使用した招待可能なメールドメインの制限ロジックを追加

### セキュリティと修正
- **PKCE Flow 対応**: `/auth/confirm` ルートを新設し、`token_hash` を使用した安全なトークン検証フローを実装。
- **Storageの保護**: ストレージ操作をサーバーサイド（管理者クライアント）経由に限定し、バケットのRLSを強化への布石。
- **認証フローの柔軟性**: Supabaseの設定にかかわらず動作するよう、PKCE FlowとImplicit Flowの両方に対応したクライアント（フォールバック）とサーバーサイド実装。
- **ビルドエラーの解消**: `useSearchParams` を `Suspense` でラップし、Next.jsのビルドエラーを修正。

## 動作確認
- [x] 公開サインアップができないことの確認
- [x] 管理者から特定のドメイン宛に招待が送れること
- [x] 届いたメール（PKCE token_hash）からパスワード設定画面へ遷移できること
- [x] パスワード設定後に正常にログインできること
- [x] `npm run build` が正常に終了すること
